### PR TITLE
fix: vsce builds routine

### DIFF
--- a/packages/vscode-slonik-live-server/package.json
+++ b/packages/vscode-slonik-live-server/package.json
@@ -8,10 +8,15 @@
   "license": "MIT",
   "displayName": "Slonik Live Server",
   "description": "Tests Slonik SQL template tag queries, suggests table & column names and checks query costs against live PostgreSQL database",
+  "private": true,
+  "installConfig": {
+    "hoistingLimits": "dependencies",
+    "selfReferences": false
+  },
   "scripts": {
     "release": "yarn semantic-release",
     "build": "yarn dlx rimraf dist && yarn tsc -p tsconfig.build.json",
-    "vscode:prepublish": "yarn build"
+    "vscode:prepublish": "yarn build && yarn workspaces focus --production && cp -R node_modules node_modules_tmp && yarn && yarn dlx rimraf node_modules && mv node_modules_tmp node_modules"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- re-apply installConfig
- create copy of production deps to include to package bundle &
  not break vsce runtime deps